### PR TITLE
Fix blankslate for ruby 1.8.7

### DIFF
--- a/lib/json_builder/blankslate.rb
+++ b/lib/json_builder/blankslate.rb
@@ -22,7 +22,7 @@ module JSONBuilder
       # hide +instance_eval+ or any method beginning with "__".
       def hide(name)
         if instance_methods.include?(name.to_s) and
-          name !~ /^(__|instance_eval|instance_exec)/
+          name !~ /^(__|instance_eval|instance_exec|instance_variable_set)/
           @hidden_methods ||= {}
           @hidden_methods[name.to_sym] = instance_method(name)
           undef_method name

--- a/lib/json_builder/compiler.rb
+++ b/lib/json_builder/compiler.rb
@@ -76,7 +76,7 @@ module JSONBuilder
     
     def copy_instance_variables_from(object, exclude = []) #:nodoc:
       vars = object.instance_variables.map(&:to_s) - exclude.map(&:to_s)
-      vars.each { |name| instance_variable_set(name, object.instance_variable_get(name)) }
+      vars.each { |name| instance_variable_set(name.to_sym, object.instance_variable_get(name)) }
     end
     
     # There are some special methods that need to be ignored that may be matched within +@_scope+.


### PR DESCRIPTION
BlankSlate hides instance_exec which is required by compile method. I've moved BlankSlate to namespace/subdir to avoid loading of another version of BlankState.
