### PR TITLE
Include zone in times (ISO 8601)

### DIFF
--- a/lib/json_builder/extensions.rb
+++ b/lib/json_builder/extensions.rb
@@ -32,19 +32,19 @@ end
 
 class Time
   def to_builder
-    self.strftime("%Y-%m-%dT%H:%M:%S").inspect
+    iso8601.inspect
   end
 end
 
 class Date
   def to_builder
-    self.strftime("%Y-%m-%dT%H:%M:%S").inspect
+    to_time.iso8601.inspect
   end
 end
 
 class DateTime
   def to_builder
-    self.strftime("%Y-%m-%dT%H:%M:%S").inspect
+    to_time.iso8601.inspect
   end
 end
 

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -18,11 +18,13 @@ class TestCompiler < Test::Unit::TestCase
   end
 
   def test_support_all_dates
-    assert_builder_json('{"date": "2011-11-23T00:00:00", "date_time": "2001-02-03T04:05:06", "timed": "2012-01-01T00:00:00"}') do
+    actual = JSONBuilder::Compiler.generate do
       date Date.new(2011, 11, 23)
       date_time DateTime.new(2001, 2, 3, 4, 5, 6)
       timed Time.utc(2012)
     end
+    # The date will have the local time zone offset, hence the wildcard.
+    assert_match(%r{\{"date": "2011-11-23T00:00:00.*", "date_time": "2001-02-03T04:05:06Z", "timed": "2012-01-01T00:00:00Z"\}}, actual)
   end
   
   def test_should_support_all_datatypes

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -38,15 +38,16 @@ class TestValue < Test::Unit::TestCase
   end
 
   def test_time_value
-    assert_equal '"2012-01-01T00:00:00"', value(Time.utc(2012))
+    assert_equal '"2012-01-01T00:00:00Z"', value(Time.utc(2012))
   end
 
   def test_date_value
-    assert_equal '"2012-01-01T00:00:00"', value(Date.parse('2012-01-01'))
+    # This will be the local time zone offset, hence the wildcard.
+    assert_match /"2012-01-01T00:00:00.*/, value(Date.parse('2012-01-01'))
   end
 
   def test_date_time_value
-    assert_equal '"2012-01-01T00:00:00"', value(DateTime.parse('2012-01-01'))
+    assert_equal '"2012-01-01T00:00:00Z"', value(DateTime.parse('2012-01-01'))
   end
 
   def test_hash_value


### PR DESCRIPTION
This lib doesn't include timezones for time/date types, but really should. Rails `to_json` uses a format with zone.

I'm afraid I couldn't find a cleaner way than this.
