### PR TITLE
use String#to_json to prevent UTF8 byte splicing

### DIFF
--- a/lib/json_builder/extensions.rb
+++ b/lib/json_builder/extensions.rb
@@ -14,7 +14,7 @@ end
 
 class String
   def to_builder
-    self.inspect
+    self.to_json
   end
 end
 


### PR DESCRIPTION
I've had problems with UTF8 text in json responses.
The problem is rooted in ruby's String#inspect that splices the last bytes of the string due to incorrect count of bytes.
String#to_json handles this well.
