### PR TITLE
Get the right time zone from Rails' TimeWithZone.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     json_builder (3.0.7)
       activesupport (>= 2.0.0)
+      tzinfo
 
 GEM
   remote: http://rubygems.org/
@@ -12,6 +13,7 @@ GEM
     i18n (0.5.0)
     multi_json (1.0.4)
     rake (0.9.2.2)
+    tzinfo (0.3.30)
 
 PLATFORMS
   ruby

--- a/json_builder.gemspec
+++ b/json_builder.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'activesupport', '>= 2.0.0'
+  s.add_dependency 'tzinfo'
 end

--- a/lib/json_builder/extensions.rb
+++ b/lib/json_builder/extensions.rb
@@ -30,6 +30,12 @@ class NilClass
   end
 end
 
+class ActiveSupport::TimeWithZone
+  def to_builder
+    iso8601.inspect
+  end
+end
+
 class Time
   def to_builder
     iso8601.inspect

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -22,9 +22,11 @@ class TestCompiler < Test::Unit::TestCase
       date Date.new(2011, 11, 23)
       date_time DateTime.new(2001, 2, 3, 4, 5, 6)
       timed Time.utc(2012)
+      Time.zone = "CET"
+      zoned Time.zone.local(2012)
     end
     # The date will have the local time zone offset, hence the wildcard.
-    assert_match(%r{\{"date": "2011-11-23T00:00:00.*", "date_time": "2001-02-03T04:05:06Z", "timed": "2012-01-01T00:00:00Z"\}}, actual)
+    assert_match(%r{\{"date": "2011-11-23T00:00:00.*", "date_time": "2001-02-03T04:05:06Z", "timed": "2012-01-01T00:00:00Z", "zoned": "2012-01-01T00:00:00\+01:00"\}}, actual)
   end
   
   def test_should_support_all_datatypes

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -25,6 +25,10 @@ class TestExtensions < Test::Unit::TestCase
     assert_respond_to nil, :to_builder
   end
   
+  def test_time_with_zone_value
+    assert_respond_to Time.zone.now, :to_builder
+  end
+
   def test_time_value
     assert_respond_to Time.utc(2012), :to_builder
   end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -41,6 +41,11 @@ class TestValue < Test::Unit::TestCase
     assert_equal '"2012-01-01T00:00:00Z"', value(Time.utc(2012))
   end
 
+  def test_time_with_zone_value
+    Time.zone = "CET"
+    assert_equal '"2012-01-01T00:00:00+01:00"', value(Time.zone.local(2012))
+  end
+
   def test_date_value
     # This will be the local time zone offset, hence the wildcard.
     assert_match /"2012-01-01T00:00:00.*/, value(Date.parse('2012-01-01'))


### PR DESCRIPTION
Without this fix, Ruby on Rails TimeWithZone#to_builder will incorrectly assume that a local time is UTC.

Sorry I missed this in the last pull request. Was a bit tricky to chase down. Seems like `TimeWithZone` passes stuff onto `Time` and loses time zone awareness on the way.
