### PR TITLE
Fixed issue where it was impossible to turn off JSON callback wrapping

### DIFF
--- a/lib/json_builder/compiler.rb
+++ b/lib/json_builder/compiler.rb
@@ -44,9 +44,9 @@ module JSONBuilder
     # Returns instance of JSONBuilder::Compiler.
     def initialize(options={})
       @_members = []
-      @_scope = options[:scope]
-      @_callback = options.has_key?(:callback) ? options[:callback] : true
-      @_pretty_print = options.has_key?(:pretty) ? options[:pretty] : false
+      @_scope = options.fetch(:scope, nil)
+      @_callback = options.fetch(:callback, true)
+      @_pretty_print = options.fetch(:pretty, false)
 
       # Only copy instance variables if there is a scope and presence of Rails
       copy_instance_variables_from(@_scope) if @_scope


### PR DESCRIPTION
Hi!

It was impossible to turn off json_callback via configuration files because it always fall backs to default "true" value.. Eg it results a double wrapping when using json_builder with rack_contrib (old one).
