### PR TITLE
Adding Moped::BSON::ObjectId to extensions to properly handle Mongoid 3.0.0+ documents ids

### DIFF
--- a/lib/json_builder/extensions.rb
+++ b/lib/json_builder/extensions.rb
@@ -74,10 +74,22 @@ class DateTime
   end
 end
 
+# Mongoid < 3.0.0
 module BSON
   class ObjectId
     def to_builder
       %("#{self}")
+    end
+  end
+end
+
+# Mongoid >= 3.0.0
+module Moped
+  module BSON
+    class ObjectId
+      def to_builder
+        %("#{self}")
+      end
     end
   end
 end

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -45,6 +45,10 @@ class TestExtensions < Test::Unit::TestCase
     assert_respond_to BSON::ObjectId.new, :to_builder
   end
 
+  def test_moped_bson_objectid_value
+    assert_respond_to Moped::BSON::ObjectId.new, :to_builder
+  end
+
   def test_custom_class
     assert_respond_to Dozer.new('hello'), :to_builder
   end


### PR DESCRIPTION
... otherwise, you are forced to call to_s on the document id to avoid a JSON::ParseError exception.
