### PR TITLE
Re-introduce escaping of tabs.

### DIFF
--- a/lib/json_builder/extensions.rb
+++ b/lib/json_builder/extensions.rb
@@ -19,6 +19,7 @@ class String
     "\r\n"  => '\n',
     "\n"    => '\n',
     "\r"    => '\n',
+    "\t"    => '\t',
     '"'     => '\\"',
     "'"     => "\'"
   }
@@ -30,7 +31,7 @@ class String
   private
 
   def json_escape
-    gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) { |match|
+    gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\t\n\r"'])/u) { |match|
       JS_ESCAPE_MAP[match]
     }
   end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -100,4 +100,10 @@ class TestCompiler < Test::Unit::TestCase
       newline "hello\nworld"
     end
   end
+
+  def test_tab_characters
+    assert_builder_json('{"tab": "hello\tworld"}') do
+      tab "hello\tworld"
+    end
+  end
 end


### PR DESCRIPTION
I ran into a problem upgrading to the latest version of json_builder.  A recent [commit](https://github.com/dewski/json_builder/commit/ea0969934da6ccddde717e3d6ba4bb6b12f01704) refactored `String#json_escape`, and removed escaping of tabs. 

The result:

```
irb> val = "a\tb"
=> "a\tb"
irb> j = JSONBuilder::Compiler.generate { v val }
=> "{\"v\": \"a\tb\"}"
irb> JSON.parse j
JSON::ParserError: 757: unexpected token at '{"v": "a   b"}'
    from /Users/jrallison/.rbenv/versions/1.9.3-p194-perf/gemsets/customerio/gems/json_pure-1.7.4/lib/json/common.rb:155:in `parse'
    from /Users/jrallison/.rbenv/versions/1.9.3-p194-perf/gemsets/customerio/gems/json_pure-1.7.4/lib/json/common.rb:155:in `parse'
    from (irb):6
    from /Users/jrallison/.rbenv/versions/1.9.3-p194-perf/gemsets/customerio/gems/railties-3.2.2/lib/rails/commands/console.rb:47:in `start'
    from /Users/jrallison/.rbenv/versions/1.9.3-p194-perf/gemsets/customerio/gems/railties-3.2.2/lib/rails/commands/console.rb:8:in `start'
    from /Users/jrallison/.rbenv/versions/1.9.3-p194-perf/gemsets/customerio/gems/railties-3.2.2/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```

This pull request adds back tab escaping.
